### PR TITLE
add missing itemprop for title

### DIFF
--- a/src/Resources/contao/templates/events/event_teaser.html5
+++ b/src/Resources/contao/templates/events/event_teaser.html5
@@ -10,7 +10,7 @@
   <?php if ($this->hasDetails): ?>
     <h2 itemprop="name"><a href="<?= $this->href ?>" title="<?= $this->title ?> (<?php if ($this->day) echo $this->day . ', '; ?><?= $this->date ?><?php if ($this->time) echo ', ' . $this->time; ?>)"<?= $this->target ?> itemprop="url"><?= $this->link ?></a></h2>
   <?php else: ?>
-    <h2><?= $this->title ?></h2>
+    <h2 itemprop="name"><?= $this->title ?></h2>
   <?php endif; ?>
 
   <p class="time"><time datetime="<?= $this->datetime ?>" itemprop="startDate"><?= $this->date ?><?php if ($this->time): ?>, <?= $this->time ?><?php endif; ?></time></p>


### PR DESCRIPTION
The `event_teaser` template is missing the `itemprop="name"` attribute on the title, if the event does not have any details.