### PR TITLE
[RTM] Added the insert tag flag for absolute URLs

### DIFF
--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -48,10 +48,13 @@ class InsertTagsListener
      * Replaces calendar insert tags.
      *
      * @param string $tag
+     * @param bool   $useCache
+     * @param mixed  $cacheValue
+     * @param array  $flags
      *
      * @return string|false
      */
-    public function onReplaceInsertTags(string $tag)
+    public function onReplaceInsertTags(string $tag, bool $useCache, $cacheValue, array $flags)
     {
         $elements = explode('::', $tag);
         $key = strtolower($elements[0]);
@@ -61,7 +64,7 @@ class InsertTagsListener
         }
 
         if (\in_array($key, self::$supportedTags, true)) {
-            return $this->replaceEventInsertTag($key, $elements[1]);
+            return $this->replaceEventInsertTag($key, $elements[1], $flags);
         }
 
         return false;
@@ -93,10 +96,11 @@ class InsertTagsListener
      *
      * @param string $insertTag
      * @param string $idOrAlias
+     * @param array  $flags
      *
      * @return string
      */
-    private function replaceEventInsertTag(string $insertTag, string $idOrAlias): string
+    private function replaceEventInsertTag(string $insertTag, string $idOrAlias, array $flags): string
     {
         $this->framework->initialize();
 
@@ -107,7 +111,7 @@ class InsertTagsListener
             return '';
         }
 
-        return $this->generateReplacement($event, $insertTag);
+        return $this->generateReplacement($event, $insertTag, $flags);
     }
 
     /**
@@ -115,10 +119,11 @@ class InsertTagsListener
      *
      * @param CalendarEventsModel $event
      * @param string              $insertTag
+     * @param array               $flags
      *
      * @return string
      */
-    private function generateReplacement(CalendarEventsModel $event, string $insertTag): string
+    private function generateReplacement(CalendarEventsModel $event, string $insertTag, array $flags): string
     {
         /** @var Events $adapter */
         $adapter = $this->framework->getAdapter(Events::class);
@@ -140,7 +145,7 @@ class InsertTagsListener
                 );
 
             case 'event_url':
-                return $adapter->generateEventUrl($event);
+                return $adapter->generateEventUrl($event, \in_array('absolute', $flags, true));
 
             case 'event_title':
                 return StringUtil::specialchars($event->title);

--- a/src/EventListener/InsertTagsListener.php
+++ b/src/EventListener/InsertTagsListener.php
@@ -54,7 +54,7 @@ class InsertTagsListener
      *
      * @return string|false
      */
-    public function onReplaceInsertTags(string $tag, bool $useCache, $cacheValue, array $flags)
+    public function onReplaceInsertTags(string $tag, bool $useCache = false, $cacheValue = null, array $flags = [])
     {
         $elements = explode('::', $tag);
         $key = strtolower($elements[0]);
@@ -132,7 +132,7 @@ class InsertTagsListener
             case 'event':
                 return sprintf(
                     '<a href="%s" title="%s">%s</a>',
-                    $adapter->generateEventUrl($event),
+                    $adapter->generateEventUrl($event, \in_array('absolute', $flags, true)),
                     StringUtil::specialchars($event->title),
                     $event->title
                 );
@@ -140,7 +140,7 @@ class InsertTagsListener
             case 'event_open':
                 return sprintf(
                     '<a href="%s" title="%s">',
-                    $adapter->generateEventUrl($event),
+                    $adapter->generateEventUrl($event, \in_array('absolute', $flags, true)),
                     StringUtil::specialchars($event->title)
                 );
 

--- a/src/Resources/contao/classes/Events.php
+++ b/src/Resources/contao/classes/Events.php
@@ -390,7 +390,7 @@ abstract class Events extends \Module
 	 * Generate a URL and return it as string
 	 *
 	 * @param CalendarEventsModel $objEvent
-	 * @param bool                $blnAbsolute
+	 * @param boolean             $blnAbsolute
 	 *
 	 * @return string
 	 */
@@ -434,7 +434,7 @@ abstract class Events extends \Module
 			case 'article':
 				if (($objArticle = \ArticleModel::findByPk($objEvent->articleId, array('eager'=>true))) !== null && ($objPid = $objArticle->getRelated('pid')) instanceof PageModel)
 				{
-				    $params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
+					$params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
 
 					/** @var PageModel $objPid */
 					self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
@@ -453,7 +453,8 @@ abstract class Events extends \Module
 			}
 			else
 			{
-			    $params = (\Config::get('useAutoItem') ? '/' : '/events/') . ($objEvent->alias ?: $objEvent->id);
+				$params = (\Config::get('useAutoItem') ? '/' : '/events/') . ($objEvent->alias ?: $objEvent->id);
+
 				self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
 			}
 		}

--- a/src/Resources/contao/classes/Events.php
+++ b/src/Resources/contao/classes/Events.php
@@ -390,12 +390,13 @@ abstract class Events extends \Module
 	 * Generate a URL and return it as string
 	 *
 	 * @param CalendarEventsModel $objEvent
+	 * @param bool                $blnAbsolute
 	 *
 	 * @return string
 	 */
-	public static function generateEventUrl($objEvent)
+	public static function generateEventUrl($objEvent, $blnAbsolute=false)
 	{
-		$strCacheKey = 'id_' . $objEvent->id;
+		$strCacheKey = 'id_' . $objEvent->id . ($blnAbsolute ? '_absolute' : '');
 
 		// Load the URL from cache
 		if (isset(self::$arrUrlCache[$strCacheKey]))
@@ -425,7 +426,7 @@ abstract class Events extends \Module
 				if (($objTarget = $objEvent->getRelated('jumpTo')) instanceof PageModel)
 				{
 					/** @var PageModel $objTarget */
-					self::$arrUrlCache[$strCacheKey] = ampersand($objTarget->getFrontendUrl());
+					self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objTarget->getAbsoluteUrl() : $objTarget->getFrontendUrl());
 				}
 				break;
 
@@ -433,8 +434,10 @@ abstract class Events extends \Module
 			case 'article':
 				if (($objArticle = \ArticleModel::findByPk($objEvent->articleId, array('eager'=>true))) !== null && ($objPid = $objArticle->getRelated('pid')) instanceof PageModel)
 				{
+				    $params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
+
 					/** @var PageModel $objPid */
-					self::$arrUrlCache[$strCacheKey] = ampersand($objPid->getFrontendUrl('/articles/' . ($objArticle->alias ?: $objArticle->id)));
+					self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params));
 				}
 				break;
 		}
@@ -450,7 +453,8 @@ abstract class Events extends \Module
 			}
 			else
 			{
-				self::$arrUrlCache[$strCacheKey] = ampersand($objPage->getFrontendUrl((\Config::get('useAutoItem') ? '/' : '/events/') . ($objEvent->alias ?: $objEvent->id)));
+			    $params = (\Config::get('useAutoItem') ? '/' : '/events/') . ($objEvent->alias ?: $objEvent->id);
+				self::$arrUrlCache[$strCacheKey] = ampersand($blnAbsolute ? $objPage->getAbsoluteUrl($params) : $objPage->getFrontendUrl($params));
 			}
 		}
 

--- a/tests/EventListener/InsertTagsListenerTest.php
+++ b/tests/EventListener/InsertTagsListenerTest.php
@@ -64,27 +64,32 @@ class InsertTagsListenerTest extends ContaoTestCase
 
         $this->assertSame(
             '<a href="events/the-foobar-event.html" title="The &quot;foobar&quot; event">The "foobar" event</a>',
-            $listener->onReplaceInsertTags('event::2')
+            $listener->onReplaceInsertTags('event::2', false, null, [])
         );
 
         $this->assertSame(
             '<a href="events/the-foobar-event.html" title="The &quot;foobar&quot; event">',
-            $listener->onReplaceInsertTags('event_open::2')
+            $listener->onReplaceInsertTags('event_open::2', false, null, [])
         );
 
         $this->assertSame(
             'events/the-foobar-event.html',
-            $listener->onReplaceInsertTags('event_url::2')
+            $listener->onReplaceInsertTags('event_url::2', false, null, [])
+        );
+
+        $this->assertSame(
+            'http://domain.tld/events/the-foobar-event.html',
+            $listener->onReplaceInsertTags('event_url::2', false, null, ['absolute'])
         );
 
         $this->assertSame(
             'The &quot;foobar&quot; event',
-            $listener->onReplaceInsertTags('event_title::2')
+            $listener->onReplaceInsertTags('event_title::2', false, null, [])
         );
 
         $this->assertSame(
             '<p>The annual foobar event.</p>',
-            $listener->onReplaceInsertTags('event_teaser::2')
+            $listener->onReplaceInsertTags('event_teaser::2', false, null, [])
         );
     }
 
@@ -92,7 +97,7 @@ class InsertTagsListenerTest extends ContaoTestCase
     {
         $listener = new InsertTagsListener($this->mockContaoFramework());
 
-        $this->assertFalse($listener->onReplaceInsertTags('link_url::2'));
+        $this->assertFalse($listener->onReplaceInsertTags('link_url::2', false, null, []));
     }
 
     public function testReturnsAnEmptyStringIfThereIsNoModel(): void
@@ -104,7 +109,7 @@ class InsertTagsListenerTest extends ContaoTestCase
 
         $listener = new InsertTagsListener($this->mockContaoFramework($adapters));
 
-        $this->assertSame('', $listener->onReplaceInsertTags('calendar_feed::3'));
-        $this->assertSame('', $listener->onReplaceInsertTags('event_url::3'));
+        $this->assertSame('', $listener->onReplaceInsertTags('calendar_feed::3', false, null, []));
+        $this->assertSame('', $listener->onReplaceInsertTags('event_url::3', false, null, []));
     }
 }


### PR DESCRIPTION
Allows for `{{event_url::123|absolute}}`. Related to https://github.com/contao/core-bundle/pull/970/. 

Instead of updating so many tests I could also have just added the argument default values in `onReplaceInsertTags` method but I wasn't sure about that. What's your opinion?