### PR TITLE
Pass the number of events to the main template

### DIFF
--- a/src/Resources/contao/modules/ModuleEventlist.php
+++ b/src/Resources/contao/modules/ModuleEventlist.php
@@ -351,6 +351,7 @@ class ModuleEventlist extends Events
 		// See #3672
 		$this->Template->headline = $this->headline;
 		$this->Template->events = $strEvents;
+		$this->Template->eventCount = $eventCount;
 
 		// Clear the $_GET array (see #2445)
 		if ($blnClearInput)


### PR DESCRIPTION
Necessary if I want to hide the list template alltogether if there are no events.